### PR TITLE
Adding callbacks for draft creation, update, and destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ source: it's a nice clean example of a gem that hooks into Rails and Sinatra.
    for separate models.
 -  Supports custom draft classes so different models' drafts can have different behavior.
 -  Supports custom name for `draft` association.
+-  Supports `before`, `after`, and `around` callbacks on each draft persistence method, such as `before_draft_creation` or `around_draft_update`
 -  Threadsafe.
 
 ## Compatibility
@@ -292,6 +293,29 @@ draft.draft_publication_dependencies
 draft.draft_reversion_dependencies
 ```
 
+### Callbacks
+
+Draftsman supports callbacks for draft creation, update, and destroy.  These callbacks can be defined in any model that `has_drafts`.
+
+Draft callbacks work similarly to ActiveRecord callbacks; pass any functions you would like called before/around/after a draft persistence method.
+
+Available callbacks:
+```ruby
+before_draft_creation   # called before draft is created
+around_draft_creation   # called function must yield to `draft_creation`
+after_draft_creation    # called after draft is created
+
+before_draft_update     # called before draft is updated
+around_draft_update     # called function must yield to `draft_update`
+after_draft_update      # called after draft is updated
+
+before_draft_destroy    # called before draft is destroyed
+around_draft_destroy    # called function must yield to `draft_destroy`
+after_draft_destroy     # called after draft is destroyed
+```
+
+Note that callbacks must be defined after your call to `has_drafts`.
+
 ## Basic Usage
 
 A basic `widgets` admin controller in Rails that saves all of the user's actions as drafts would look something like
@@ -457,6 +481,31 @@ private
 end
 
 ```
+
+If you would like your Widget to have callbacks, it might look something like this:
+
+```ruby
+class Widget < ActiveRecord::Base
+  has_drafts
+
+  before_draft_creation :say_hi
+  around_draft_update :surround_update
+
+
+  private
+
+  def say_hi
+    self.some_attr = 'Hi!'
+  end
+
+  def surround_update
+    # do something before update
+    yield
+    # do something after update
+  end
+end
+```
+
 
 ## Differences from PaperTrail
 

--- a/spec/dummy/app/models/talkative.rb
+++ b/spec/dummy/app/models/talkative.rb
@@ -1,0 +1,66 @@
+class Talkative < ActiveRecord::Base
+  has_drafts
+
+  # draft_creation callbacks
+  before_draft_creation :do_this_before_draft_creation
+  around_draft_creation :do_this_around_draft_creation
+  after_draft_creation :do_this_after_draft_creation
+
+  # draft_update callbacks
+  before_draft_update :do_this_before_draft_update
+  around_draft_update :do_this_around_draft_update
+  after_draft_update :do_this_after_draft_update
+
+  # # draft_destroy callbacks
+  before_draft_destroy :do_this_before_draft_destroy
+  around_draft_destroy :do_this_around_draft_destroy
+  after_draft_destroy :do_this_after_draft_destroy
+
+
+
+  def do_this_before_draft_creation
+    self.before_comment = "I changed before creation"
+  end
+
+  def do_this_around_draft_creation
+    self.around_early_comment = "I changed around creation (before yield)"
+    yield
+    self.around_late_comment = "I changed around creation (after yield)"
+  end
+
+  def do_this_after_draft_creation
+    self.after_comment = "I changed after creation"
+  end
+
+
+
+  def do_this_before_draft_update
+    self.before_comment = "I changed before update"
+  end
+
+  def do_this_around_draft_update
+    self.around_early_comment = "I changed around update (before yield)"
+    yield
+    self.around_late_comment = "I changed around update (after yield)"
+  end
+
+  def do_this_after_draft_update
+    self.after_comment = "I changed after update"
+  end
+
+
+
+  def do_this_before_draft_destroy
+    self.before_comment = "I changed before destroy"
+  end
+
+  def do_this_around_draft_destroy
+    self.around_early_comment = "I changed around destroy (before yield)"
+    yield
+    self.around_late_comment = "I changed around destroy (after yield)"
+  end
+
+  def do_this_after_draft_destroy
+    self.after_comment = "I changed after destroy"
+  end
+end

--- a/spec/dummy/db/migrate/20150404203627_add_talkatives_table_to_tests.rb
+++ b/spec/dummy/db/migrate/20150404203627_add_talkatives_table_to_tests.rb
@@ -1,0 +1,18 @@
+class AddTalkativesTableToTests < ActiveRecord::Migration
+  def self.up
+    create_table :talkatives, :force => true do |t|
+      t.string     :before_comment
+      t.string     :around_early_comment
+      t.string     :around_late_comment
+      t.string     :after_comment
+      t.references :draft
+      t.datetime   :trashed_at
+      t.datetime   :published_at
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :talkatives
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,20 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20110208155312) do
+ActiveRecord::Schema.define(version: 20150404203627) do
 
-  create_table "bastards", force: true do |t|
+  create_table "bastards", force: :cascade do |t|
     t.string   "name"
     t.integer  "parent_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "change_hoarders", force: true do |t|
-    t.integer "draft_id"
-  end
-
-  create_table "children", force: true do |t|
+  create_table "children", force: :cascade do |t|
     t.string   "name"
     t.integer  "parent_id"
     t.integer  "draft_id"
@@ -34,16 +30,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "clingy_parents", force: true do |t|
-    t.string   "name"
-    t.integer  "draft_id"
-    t.datetime "trashed_at"
-    t.datetime "published_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "draft_as_sketches", force: true do |t|
+  create_table "draft_as_sketches", force: :cascade do |t|
     t.string   "name"
     t.integer  "sketch_id"
     t.datetime "published_at"
@@ -51,17 +38,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "draft_dependencies", force: true do |t|
-    t.integer "draft_id",      null: false
-    t.integer "dependency_id", null: false
-  end
-
-  create_table "draft_dependents", force: true do |t|
-    t.integer "draft_id",     null: false
-    t.integer "dependent_id", null: false
-  end
-
-  create_table "drafts", force: true do |t|
+  create_table "drafts", force: :cascade do |t|
     t.string   "item_type"
     t.integer  "item_id"
     t.string   "event",          null: false
@@ -76,27 +53,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string   "user_agent"
   end
 
-  create_table "hopeless_children", force: true do |t|
-    t.string   "name"
-    t.integer  "clingy_parent_id"
-    t.integer  "draft_id"
-    t.datetime "trashed_at"
-    t.datetime "published_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "mortgages", force: true do |t|
-    t.float    "amount"
-    t.integer  "parent_id"
-    t.integer  "draft_id"
-    t.datetime "trashed_at"
-    t.datetime "published_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "parents", force: true do |t|
+  create_table "parents", force: :cascade do |t|
     t.string   "name"
     t.integer  "draft_id"
     t.datetime "trashed_at"
@@ -105,7 +62,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "skippers", force: true do |t|
+  create_table "skippers", force: :cascade do |t|
     t.string   "name"
     t.string   "skip_me"
     t.integer  "draft_id"
@@ -115,7 +72,19 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "trashables", force: true do |t|
+  create_table "talkatives", force: :cascade do |t|
+    t.string   "before_comment"
+    t.string   "around_early_comment"
+    t.string   "around_late_comment"
+    t.string   "after_comment"
+    t.integer  "draft_id"
+    t.datetime "trashed_at"
+    t.datetime "published_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "trashables", force: :cascade do |t|
     t.string   "name"
     t.string   "title"
     t.integer  "draft_id"
@@ -125,7 +94,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "vanillas", force: true do |t|
+  create_table "vanillas", force: :cascade do |t|
     t.string   "name"
     t.integer  "draft_id"
     t.datetime "published_at"
@@ -133,7 +102,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "whitelisters", force: true do |t|
+  create_table "whitelisters", force: :cascade do |t|
     t.string   "name"
     t.string   "ignored"
     t.integer  "draft_id"

--- a/spec/models/talkative_spec.rb
+++ b/spec/models/talkative_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+
+# A Talkative has a call to `has_drafts` and all nine callbacks defined:
+#  before_draft_creation, around_draft_creation, after_draft_creation
+#  before_draft_update, around_draft_update, after_draft_update
+#  before_draft_destroy, around_draft_destroy, after_draft_destroy
+
+describe 'Talkative' do
+  let(:talkative) { Talkative.new }
+
+  it 'is draftable' do
+    expect(talkative.class.draftable?).to eql true
+  end
+
+
+  describe 'draft_creation' do
+    before do
+      talkative.draft_creation
+    end
+
+    context 'before callback' do
+      it 'updates attribute' do
+        expect(talkative.before_comment).to eql "I changed before creation"
+      end
+
+      it 'persists updated attribute to draft' do
+        talkative.reload
+        expect(talkative.draft.reify.before_comment).to eql "I changed before creation"
+      end
+    end
+
+    context 'around callback' do
+      it 'updates attribute (before yield)' do
+        expect(talkative.around_early_comment).to eql "I changed around creation (before yield)"
+      end
+
+      it 'persists updated attribute to draft' do
+        talkative.reload
+        expect(talkative.draft.reify.around_late_comment).to be_nil
+      end
+
+      it 'updates attribute (after yield)' do
+        expect(talkative.around_early_comment).to eql "I changed around creation (before yield)"
+      end
+
+      it 'does not persist updated attribute' do
+        talkative.reload
+        expect(talkative.around_late_comment).to be_nil
+        expect(talkative.draft.reify.around_late_comment).to be_nil
+      end
+    end
+
+    context 'after callback' do
+      it 'updates attribute' do
+        expect(talkative.after_comment).to eql "I changed after creation"
+      end
+
+      it 'does not persist updated attribute' do
+        talkative.reload
+        expect(talkative.after_comment).to be_nil
+        expect(talkative.draft.reify.after_comment).to be_nil
+      end
+    end
+  end
+
+
+  describe 'draft_update' do
+    before do
+      talkative.draft_update
+    end
+
+    context 'before callback' do
+      it 'updates attribute' do
+        expect(talkative.before_comment).to eql "I changed before update"
+      end
+
+      it 'persists updated attribute to draft' do
+        talkative.reload
+        expect(talkative.draft.reify.before_comment).to eql "I changed before update"
+      end
+    end
+
+    context 'around callback' do
+      it 'updates attribute (before yield)' do
+        expect(talkative.around_early_comment).to eql "I changed around update (before yield)"
+      end
+
+      it 'persists updated attribute to draft' do
+        talkative.reload
+        expect(talkative.draft.reify.around_late_comment).to be_nil
+      end
+
+      it 'updates attribute (after yield)' do
+        expect(talkative.around_early_comment).to eql "I changed around update (before yield)"
+      end
+
+      it 'does not persist updated attribute' do
+        talkative.reload
+        expect(talkative.around_late_comment).to be_nil
+        expect(talkative.draft.reify.around_late_comment).to be_nil
+      end
+    end
+
+    context 'after callback' do
+      it 'updates attribute' do
+        expect(talkative.after_comment).to eql "I changed after update"
+      end
+
+      it 'does not persist updated attribute' do
+        talkative.reload
+        expect(talkative.after_comment).to be_nil
+        expect(talkative.draft.reify.after_comment).to be_nil
+      end
+    end
+  end
+
+
+  describe 'draft_destroy' do
+    before do
+      talkative.draft_destroy
+    end
+
+    context 'before callback' do
+      it 'updates attribute' do
+        expect(talkative.before_comment).to eql "I changed before destroy"
+      end
+
+      it 'persists updated attribute to draft' do
+        talkative.reload
+        expect(talkative.draft.reify.before_comment).to eql "I changed before destroy"
+      end
+    end
+
+    context 'around callback' do
+      it 'updates attribute (before yield)' do
+        expect(talkative.around_early_comment).to eql "I changed around destroy (before yield)"
+      end
+
+      it 'persists updated attribute to draft' do
+        talkative.reload
+        expect(talkative.draft.reify.around_late_comment).to be_nil
+      end
+
+      it 'updates attribute (after yield)' do
+        expect(talkative.around_early_comment).to eql "I changed around destroy (before yield)"
+      end
+
+      it 'does not persist updated attribute' do
+        talkative.reload
+        expect(talkative.around_late_comment).to be_nil
+        expect(talkative.draft.reify.around_late_comment).to be_nil
+      end
+    end
+
+    context 'after callback' do
+      it 'updates attribute' do
+        expect(talkative.after_comment).to eql "I changed after destroy"
+      end
+
+      it 'does not persist updated attribute' do
+        talkative.reload
+        expect(talkative.after_comment).to be_nil
+        expect(talkative.draft.reify.after_comment).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey @chrisdpeters -- I had a few situations where I needed ActiveRecord-style callbacks to run on draft content, e.g. `before_draft_creation` rather than ActiveRecord's `before_create`.

This pull request includes support for nine callbacks:
(before | around | after)_draft_creation
(before | around | after)_draft_update
(before | around | after)_draft_destroy

I've included multiple tests for each of these callbacks -- 25 in total.

For the most part, I haven't changed how draftsman works (and the current specs all pass).  The `draft_creation`, `draft_update`, and `draft_destroy` methods are basically just wrapped by the callbacks.  There is one change to model.rb#L225 -- I've moved the 'return' outside of the callbacks to make sure they always have a chance to run (unless there is an exception).

Thought you (or others) might find this useful.  Let me know if you have questions, or if you'd like me to modify how I'm doing anything.

Thanks!