### PR TITLE
Fixes #13 - LoadError when trying to run migrations

### DIFF
--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])


### PR DESCRIPTION
Fixes [#13](https://github.com/liveeditor/draftsman/issues/13)

When following the guide for contributions, it's possible to get a LoadError when trying to run `RAILS_ENV=test rake db:migrate` from the `spec/dummy` directory.
```
LoadError: cannot load such file -- draftsman
<path>/draftsman/spec/dummy/config/application.rb:9:in `<top (required)>'
<path>/draftsman/spec/dummy/Rakefile:5:in `<top (required)>'
```

This fix points to the proper Gemfile (it seems that the path was wrong before), which fixes the LoadError.