### PR TITLE
Fixes #22 - Exception on draft_destroy when has_one association is nil

### DIFF
--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -259,11 +259,12 @@ module Draftsman
           dependent_associations.each do |association|
 
             if association.klass.draftable? && association.options.has_key?(:dependent) && association.options[:dependent] == :destroy
-              dependents = association.macro == :has_one ? [self.send(association.name)] : self.send(association.name)
+              dependents = self.send(association.name)
+              dependents = [dependents] if (dependents && association.macro == :has_one)
 
               dependents.each do |dependent|
                 dependent.draft_destroy unless dependent.draft? && dependent.send(dependent.class.draft_association_name).destroy?
-              end
+              end if dependents
             end
           end
         end

--- a/spec/dummy/app/models/only_child.rb
+++ b/spec/dummy/app/models/only_child.rb
@@ -1,0 +1,4 @@
+class OnlyChild < ActiveRecord::Base
+  has_drafts
+  belongs_to :parent
+end

--- a/spec/dummy/app/models/parent.rb
+++ b/spec/dummy/app/models/parent.rb
@@ -2,4 +2,5 @@ class Parent < ActiveRecord::Base
   has_drafts
   has_many :children, :dependent => :destroy
   has_many :bastards, :dependent => :destroy
+  has_one :only_child, :dependent => :destroy
 end

--- a/spec/dummy/db/migrate/20150408234937_add_only_children.rb
+++ b/spec/dummy/db/migrate/20150408234937_add_only_children.rb
@@ -1,0 +1,16 @@
+class AddOnlyChildren < ActiveRecord::Migration
+  def up
+    create_table :only_children, :force => true do |t|
+      t.string     :name
+      t.references :parent
+      t.references :draft
+      t.datetime   :trashed_at
+      t.datetime   :published_at
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :only_children
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,20 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20110208155312) do
+ActiveRecord::Schema.define(version: 20150408234937) do
 
-  create_table "bastards", force: true do |t|
+  create_table "bastards", force: :cascade do |t|
     t.string   "name"
     t.integer  "parent_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "change_hoarders", force: true do |t|
-    t.integer "draft_id"
-  end
-
-  create_table "children", force: true do |t|
+  create_table "children", force: :cascade do |t|
     t.string   "name"
     t.integer  "parent_id"
     t.integer  "draft_id"
@@ -34,16 +30,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "clingy_parents", force: true do |t|
-    t.string   "name"
-    t.integer  "draft_id"
-    t.datetime "trashed_at"
-    t.datetime "published_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "draft_as_sketches", force: true do |t|
+  create_table "draft_as_sketches", force: :cascade do |t|
     t.string   "name"
     t.integer  "sketch_id"
     t.datetime "published_at"
@@ -51,17 +38,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "draft_dependencies", force: true do |t|
-    t.integer "draft_id",      null: false
-    t.integer "dependency_id", null: false
-  end
-
-  create_table "draft_dependents", force: true do |t|
-    t.integer "draft_id",     null: false
-    t.integer "dependent_id", null: false
-  end
-
-  create_table "drafts", force: true do |t|
+  create_table "drafts", force: :cascade do |t|
     t.string   "item_type"
     t.integer  "item_id"
     t.string   "event",          null: false
@@ -76,18 +53,8 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.string   "user_agent"
   end
 
-  create_table "hopeless_children", force: true do |t|
+  create_table "only_children", force: :cascade do |t|
     t.string   "name"
-    t.integer  "clingy_parent_id"
-    t.integer  "draft_id"
-    t.datetime "trashed_at"
-    t.datetime "published_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "mortgages", force: true do |t|
-    t.float    "amount"
     t.integer  "parent_id"
     t.integer  "draft_id"
     t.datetime "trashed_at"
@@ -96,7 +63,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "parents", force: true do |t|
+  create_table "parents", force: :cascade do |t|
     t.string   "name"
     t.integer  "draft_id"
     t.datetime "trashed_at"
@@ -105,7 +72,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "skippers", force: true do |t|
+  create_table "skippers", force: :cascade do |t|
     t.string   "name"
     t.string   "skip_me"
     t.integer  "draft_id"
@@ -115,7 +82,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "trashables", force: true do |t|
+  create_table "trashables", force: :cascade do |t|
     t.string   "name"
     t.string   "title"
     t.integer  "draft_id"
@@ -125,7 +92,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "vanillas", force: true do |t|
+  create_table "vanillas", force: :cascade do |t|
     t.string   "name"
     t.integer  "draft_id"
     t.datetime "published_at"
@@ -133,7 +100,7 @@ ActiveRecord::Schema.define(version: 20110208155312) do
     t.datetime "updated_at"
   end
 
-  create_table "whitelisters", force: true do |t|
+  create_table "whitelisters", force: :cascade do |t|
     t.string   "name"
     t.string   "ignored"
     t.integer  "draft_id"


### PR DESCRIPTION
`self.send(association.name)` will return `nil` if the association is empty (there are no dependents).  Currently, if the association is `has_one` and the result is `nil`, it is still wrapped in an array.  When we try to access this `nil` element in the following `.each` block, an exception is thrown.

The changes to model.rb resolve this issue.  Singular dependents are only wrapped in an array if they exist (and `nil` isn't wrapped).

The `.each` block is also only called if the dependents exist.  So, whether a `has_one` or `has_many` returns `nil`, the block will be bypassed and we avoid any exceptions.

I added an `OnlyChild` class and association to the parents to easily test this fix.  Without the fix, many of the current tests will fail.  With the fix in place, the tests will run properly again.

Hope this is helpful, @chrisdpeters!  As always, let me know if you want something changed.