### PR TITLE
Fixes #28: Skipped attributes aren't updated if a model has a draft

### DIFF
--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -313,6 +313,7 @@ module Draftsman
             if send(self.class.draft_association_name).present?
               data[:object_changes] = changes_for_draftsman if track_object_changes_for_draft?
               send(self.class.draft_association_name).update_attributes data
+              update_skipped_attributes
             # If there's not draft, create an update draft.
             else
               data[:event]          = 'update'

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -253,6 +253,16 @@ describe Skipper do
         it "updates the draft's `name`" do
           expect(subject.draft.reify.name).to eql 'Steve'
         end
+        
+        it "updates skipped attribute while also updating draft attribute" do
+          subject.name = 'Tom'
+          subject.skip_me = 'Skip and save'
+          subject.draft_update
+
+          subject.reload
+          
+          expect(subject.skip_me).to eql 'Skip and save'
+        end
       end
 
       context 'with no changes' do


### PR DESCRIPTION
There was a saving inconsistency when a model has a draft vs. no draft.

* When a model did not have a draft and both skipped and non-skipped attributes were updated, the skipped attributes were updated on the model, while the non-skipped attributes were updated in a new "update" draft.
* When a model had a draft and both skipped and non-skipped attributes were updated, the skipped attributes were **not** updated on the model, and the non-skipped attributes were updated in the draft.

This commit resolves that inconsistency.  The skipped attributes are now always updated in this case, whether there is a draft or not.

A test case has been provided that shows the issue.