### PR TITLE
Prevented double require of model definition

### DIFF
--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -211,7 +211,9 @@ class Draftsman::Draft < ActiveRecord::Base
         reify_previous_draft.reify
       elsif !self.object.nil?
         # This appears to be necessary if for some reason the draft's model hasn't been loaded (such as when done in the console).
-        require self.item_type.underscore
+        unless defined? self.item_type
+          require self.item_type.underscore
+        end
 
         model = item.reload
 


### PR DESCRIPTION
The class definition was being included twice, which caused an issue with models which use enums.