### PR TITLE
Fix ActiveSupport::DeprecationException error when running generated migrations.

### DIFF
--- a/lib/generators/draftsman/templates/create_drafts.rb
+++ b/lib/generators/draftsman/templates/create_drafts.rb
@@ -7,7 +7,7 @@ class CreateDrafts < ActiveRecord::Migration
       t.string  :whodunnit#  :null => false
       t.text    :object
       t.text    :previous_draft
-      t.timestamps
+      t.timestamps,         :null => false
     end
 
     change_table :drafts do |t|

--- a/lib/generators/draftsman/templates/create_drafts.rb
+++ b/lib/generators/draftsman/templates/create_drafts.rb
@@ -7,7 +7,7 @@ class CreateDrafts < ActiveRecord::Migration
       t.string  :whodunnit#  :null => false
       t.text    :object
       t.text    :previous_draft
-      t.timestamps,         :null => false
+      t.timestamps          :null => false
     end
 
     change_table :drafts do |t|

--- a/lib/generators/draftsman/templates/create_drafts_json.rb
+++ b/lib/generators/draftsman/templates/create_drafts_json.rb
@@ -7,7 +7,7 @@ class CreateDrafts < ActiveRecord::Migration
       t.string  :whodunnit#  :null => false
       t.json    :object
       t.json    :previous_draft
-      t.timestamps
+      t.timestamps,         :null => false
     end
 
     change_table :drafts do |t|

--- a/lib/generators/draftsman/templates/create_drafts_json.rb
+++ b/lib/generators/draftsman/templates/create_drafts_json.rb
@@ -7,7 +7,7 @@ class CreateDrafts < ActiveRecord::Migration
       t.string  :whodunnit#  :null => false
       t.json    :object
       t.json    :previous_draft
-      t.timestamps,         :null => false
+      t.timestamps          :null => false
     end
 
     change_table :drafts do |t|


### PR DESCRIPTION
The migration generated from `rails g draftsman:install` was throwing an exception (Rails 4.2)

> DEPRECATION WARNING: `#timestamps` was called without specifying an option for `null`. In Rails 5, this behavior will change to `null: false`. You should manually specify `null: true` to prevent the behavior of your existing migrations from changing.

thanks!