### PR TITLE
Do not "touch" models when not updating the base table content.

### DIFF
--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -175,7 +175,7 @@ class Draftsman::Draft < ActiveRecord::Base
         self.item.attributes = self.reify.attributes if Draftsman.stash_drafted_changes? && self.update?
 
         # Write `published_at` attribute
-        self.item.send("#{self.item.class.published_at_attribute_name}=", Time.now)
+        self.item.send("#{self.item.class.published_at_attribute_name}=", current_time_from_proper_timezone)
 
         # Clear out draft
         self.item.send("#{self.item.class.draft_association_name}_id=", nil)
@@ -274,10 +274,10 @@ class Draftsman::Draft < ActiveRecord::Base
           self.changeset.each do |attr, values|
             self.item.send("#{attr}=", values.first) if self.item.respond_to?(attr)
           end
-          self.item.save!(validate: false)
         end
         # Then clear out the draft ID.
-        self.item.update_column("#{self.item.class.draft_association_name}_id", nil)
+        self.item.send("#{self.item.class.draft_association_name}_id=", nil)
+        self.item.save!(validate: false, touch: false)
         # Then destroy draft.
         self.destroy
       when :destroy

--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -274,10 +274,10 @@ class Draftsman::Draft < ActiveRecord::Base
           self.changeset.each do |attr, values|
             self.item.send("#{attr}=", values.first) if self.item.respond_to?(attr)
           end
+          self.item.save!(validate: false)
         end
         # Then clear out the draft ID.
-        self.item.send("#{self.item.class.draft_association_name}_id=", nil)
-        self.item.save!(validate: false)
+        self.item.update_column("#{self.item.class.draft_association_name}_id", nil)
         # Then destroy draft.
         self.destroy
       when :destroy

--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -180,18 +180,6 @@ class Draftsman::Draft < ActiveRecord::Base
         # Clear out draft
         self.item.send("#{self.item.class.draft_association_name}_id=", nil)
 
-        # Determine which columns should be updated
-        only   = self.item.class.draftsman_options[:only]
-        ignore = self.item.class.draftsman_options[:ignore]
-        skip   = self.item.class.draftsman_options[:skip]
-        attributes_to_change = only.any? ? only : self.item.attribute_names
-        attributes_to_change = attributes_to_change - ignore + ['published_at', "#{self.item.class.draft_association_name}_id"] - skip
-
-        # Save without validations or callbacks
-        self.item.attributes.slice(*attributes_to_change).each do |key, value|
-          self.item.send("#{key}=", value)
-        end
-
         self.item.save(validate: false)
         self.item.reload
 

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -335,12 +335,8 @@ module Draftsman
               # original values.
               if self.draft? && the_changes.empty?
                 nilified_draft = send(self.class.draft_association_name)
+                touch = changed?
                 send("#{self.class.draft_association_name}_id=", nil)
-                touch = false
-                if !Draftsman.stash_drafted_changes? ||
-                   draftsman_options[:skip].present?
-                  touch = true
-                end
                 save(touch: touch)
                 nilified_draft.destroy
               # Save an update draft if record is changed notably.

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -331,12 +331,11 @@ module Draftsman
               the_changes = changes_for_draftsman(:update)
               save_only_columns_for_draft if Draftsman.stash_drafted_changes?
 
-              # Destroy the draft if this record has changed back to the original
-              # record.
+              # Destroy the draft if this record has changed back to the
+              # original values.
               if self.draft? && the_changes.empty?
                 nilified_draft = send(self.class.draft_association_name)
                 send("#{self.class.draft_association_name}_id=", nil)
-                self.save
                 nilified_draft.destroy
               # Save an update draft if record is changed notably.
               elsif !the_changes.empty?

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -335,7 +335,8 @@ module Draftsman
               # original values.
               if self.draft? && the_changes.empty?
                 nilified_draft = send(self.class.draft_association_name)
-                self.update_column("#{self.class.draft_association_name}_id", nil)
+                send("#{self.class.draft_association_name}_id=", nil)
+                save(touch: false)
                 nilified_draft.destroy
               # Save an update draft if record is changed notably.
               elsif !the_changes.empty?

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -474,7 +474,8 @@ module Draftsman
       # Updates skipped attributes' values on this model.
       def update_skipped_attributes
         # Skip over this if nothing's being skipped.
-        return true unless draftsman_options[:skip].present?
+        skipped_changed = changed_attributes.keys & draftsman_options[:skip]
+        return true unless skipped_changed.present?
 
         keys = self.attributes.keys.select { |key| draftsman_options[:skip].include?(key) }
         attrs = {}

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -326,7 +326,7 @@ module Draftsman
 
               data = merge_metadata_for_draft(data)
               send(self.class.draft_association_name).update(data)
-              self.save
+              save
             else
               the_changes = changes_for_draftsman(:update)
               save_only_columns_for_draft if Draftsman.stash_drafted_changes?
@@ -336,7 +336,12 @@ module Draftsman
               if self.draft? && the_changes.empty?
                 nilified_draft = send(self.class.draft_association_name)
                 send("#{self.class.draft_association_name}_id=", nil)
-                save(touch: false)
+                touch = false
+                if !Draftsman.stash_drafted_changes? ||
+                   draftsman_options[:skip].present?
+                  touch = true
+                end
+                save(touch: touch)
                 nilified_draft.destroy
               # Save an update draft if record is changed notably.
               elsif !the_changes.empty?

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -335,7 +335,7 @@ module Draftsman
               # original values.
               if self.draft? && the_changes.empty?
                 nilified_draft = send(self.class.draft_association_name)
-                send("#{self.class.draft_association_name}_id=", nil)
+                self.update_column("#{self.class.draft_association_name}_id", nil)
                 nilified_draft.destroy
               # Save an update draft if record is changed notably.
               elsif !the_changes.empty?

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -153,7 +153,10 @@ RSpec.describe Skipper, type: :model do
       end
 
       context 'with existing `create` draft' do
-        before { skipper.save_draft }
+        before do
+          skipper.save_draft
+          skipper.reload
+        end
 
         context 'with changes' do
           before do
@@ -259,7 +262,8 @@ RSpec.describe Skipper, type: :model do
           end
 
           it 'has the original `updated_at`' do
-            expect(subject.updated_at).to eq skipper.updated_at
+            time = skipper.updated_at
+            expect(subject.updated_at).to eq time
           end
         end
       end

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -259,8 +259,7 @@ RSpec.describe Skipper, type: :model do
           end
 
           it 'has the original `updated_at`' do
-            time = skipper.updated_at
-            expect(subject.updated_at).to eq time
+            expect(subject.updated_at).to eq skipper.updated_at
           end
         end
       end

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe Skipper, type: :model do
       it 'has a value for `skip_me`' do
         expect(subject.skip_me).to eql 'Skipped 1'
       end
+
+      it 'sets `updated_at`' do
+        time = Time.now
+        expect(subject.updated_at).to be > time
+      end
     end
 
     context 'on update' do
@@ -99,6 +104,11 @@ RSpec.describe Skipper, type: :model do
         it 'creates a new draft' do
           expect { subject }.to change(Draftsman::Draft, :count).by(1)
         end
+
+        it 'has a newer `updated_at`' do
+          time = skipper.updated_at
+          expect(subject.updated_at).to be > time
+        end
       end
 
       describe 'changing back to initial state' do
@@ -134,6 +144,11 @@ RSpec.describe Skipper, type: :model do
 
         it 'destroys the draft' do
           expect { subject }.to change(Draftsman::Draft.where(:id => skipper.draft_id), :count).by(-1)
+        end
+
+        it 'has a newer `updated_at`' do
+          time = skipper.updated_at
+          expect(subject.updated_at).to be > time
         end
       end
 
@@ -181,6 +196,33 @@ RSpec.describe Skipper, type: :model do
           it "updates the draft's `name`" do
             expect(subject.draft.reify.name).to eql 'Sam'
           end
+
+          it 'has a newer `updated_at`' do
+            time = skipper.updated_at
+            expect(subject.updated_at).to be > time
+          end
+        end
+
+        context 'with changes to drafted attribute' do
+          before do
+            skipper.name = 'Sam'
+          end
+
+          it 'has a newer `updated_at`' do
+            time = skipper.updated_at
+            expect(subject.updated_at).to be > time
+          end
+        end
+
+        context 'with changes to skipped attribute' do
+          before do
+            skipper.skip_me = 'Skipped 2'
+          end
+
+          it 'has a newer `updated_at`' do
+            time = skipper.updated_at
+            expect(subject.updated_at).to be > time
+          end
         end
 
         context 'with no changes' do
@@ -214,6 +256,11 @@ RSpec.describe Skipper, type: :model do
 
           it "doesn't change the number of drafts" do
             expect { subject }.to_not change(Draftsman::Draft.where(:id => skipper.draft_id), :count)
+          end
+
+          it 'has the original `updated_at`' do
+            time = skipper.updated_at
+            expect(subject.updated_at).to eq time
           end
         end
       end
@@ -266,14 +313,16 @@ RSpec.describe Skipper, type: :model do
           it "updates the draft's `name`" do
             expect(subject.draft.reify.name).to eql 'Steve'
           end
+
+          it 'has the original `updated_at`' do
+            time = skipper.updated_at
+            expect(subject.updated_at).to eq time
+          end
         end
 
         context 'with changes to skipped attributes' do
           before do
             skipper.skip_me = 'Skip and save'
-            skipper.save_draft
-            skipper.reload
-            skipper.attributes = skipper.draft.reify.attributes
           end
 
           it 'is persisted' do
@@ -315,6 +364,11 @@ RSpec.describe Skipper, type: :model do
           it 'updates skipped attribute on draft' do
             expect(subject.draft.reify.skip_me).to eql 'Skip and save'
           end
+
+          it 'has a newer `updated_at`' do
+            time = skipper.updated_at
+            expect(subject.updated_at).to be > time
+          end
         end
 
         context 'with no changes' do
@@ -352,6 +406,11 @@ RSpec.describe Skipper, type: :model do
 
           it "does not update the draft's `name`" do
             expect(subject.draft.reify.name).to eql 'Sam'
+          end
+
+          it 'has the original `updated_at`' do
+            time = skipper.updated_at
+            expect(subject.updated_at).to eq time
           end
         end
       end

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -215,10 +215,11 @@ describe Vanilla do
               expect(vanilla.draft.create?).to eql true
             end
 
-            it 'has the original `updated_at`' do
+            it 'has a new `updated_at`' do
+              time = vanilla.updated_at
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).to be > time
             end
           end # with changes
 

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -536,10 +536,11 @@ describe Vanilla do
               expect(vanilla.draft.create?).to eql true
             end
 
-            it 'has the original `updated_at`' do
+            it 'has a new `updated_at`' do
+              time = vanilla.updated_at
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).to be > time
             end
           end
 

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -9,6 +9,14 @@ describe Vanilla do
     it 'contains column name' do
       expect(vanilla.object_attrs_for_draft_record).to include 'name'
     end
+
+    it 'contains column updated_at' do
+      expect(vanilla.object_attrs_for_draft_record).to include 'updated_at'
+    end
+
+    it 'contains column created_at' do
+      expect(vanilla.object_attrs_for_draft_record).to include 'created_at'
+    end
   end
 
   describe '#save_draft' do
@@ -41,6 +49,18 @@ describe Vanilla do
       it 'saves the `name`' do
         vanilla.save_draft
         expect(vanilla.name).to eql 'Bob'
+      end
+
+      it 'sets `updated_at`' do
+        time = Time.now
+        vanilla.save_draft
+        expect(vanilla.updated_at).to be > time
+      end
+
+      it 'sets `created_at`' do
+        time = Time.now
+        vanilla.save_draft
+        expect(vanilla.created_at).to be > time
       end
     end
 
@@ -90,6 +110,12 @@ describe Vanilla do
           it 'creates a new draft' do
             expect { vanilla.save_draft }.to change(Draftsman::Draft, :count).by(1)
           end
+
+          it 'has the original `updated_at`' do
+            vanilla.save_draft
+            vanilla.reload
+            expect(vanilla.updated_at).to eq vanilla.created_at
+          end
         end
 
         describe 'changing back to initial state' do
@@ -128,6 +154,12 @@ describe Vanilla do
 
           it 'destroys the draft' do
             expect { vanilla.save_draft }.to change(Draftsman::Draft.where(id: vanilla.draft_id), :count).by(-1)
+          end
+
+          it 'has the original `updated_at`' do
+            vanilla.save_draft
+            vanilla.reload
+            expect(vanilla.updated_at).to eq vanilla.created_at
           end
         end
 
@@ -182,6 +214,12 @@ describe Vanilla do
               vanilla.reload
               expect(vanilla.draft.create?).to eql true
             end
+
+            it 'has the original `updated_at`' do
+              vanilla.save_draft
+              vanilla.reload
+              expect(vanilla.updated_at).to eq vanilla.created_at
+            end
           end # with changes
 
           context 'with no changes' do
@@ -222,6 +260,12 @@ describe Vanilla do
 
             it "doesn't change the number of drafts" do
               expect { vanilla.save_draft }.to_not change(Draftsman::Draft.where(id: vanilla.draft_id), :count)
+            end
+
+            it 'has the original `updated_at`' do
+              vanilla.save_draft
+              vanilla.reload
+              expect(vanilla.updated_at).to eq vanilla.created_at
             end
           end
         end # with no changes
@@ -281,6 +325,12 @@ describe Vanilla do
               vanilla.save_draft
               expect(vanilla.draft.update?).to eql true
             end
+
+            it 'has the original `updated_at`' do
+              vanilla.save_draft
+              vanilla.reload
+              expect(vanilla.updated_at).to eq vanilla.created_at
+            end
           end # with changes
 
           context 'with no changes' do
@@ -327,6 +377,12 @@ describe Vanilla do
               vanilla.save_draft
               vanilla.reload
               expect(vanilla.draft.reify.name).to eql 'Sam'
+            end
+
+            it 'has the original `updated_at`' do
+              vanilla.save_draft
+              vanilla.reload
+              expect(vanilla.updated_at).to eq vanilla.created_at
             end
           end # with no changes
         end # with existing `update` draft
@@ -380,6 +436,13 @@ describe Vanilla do
           it 'creates a new draft' do
             expect { vanilla.save_draft }.to change(Draftsman::Draft, :count).by(1)
           end
+
+          it 'has a new `updated_at`' do
+            time = vanilla.updated_at
+            vanilla.save_draft
+            vanilla.reload
+            expect(vanilla.updated_at).to be > time
+          end
         end
 
         describe 'changing back to initial state' do
@@ -418,6 +481,13 @@ describe Vanilla do
 
           it 'destroys the draft' do
             expect { vanilla.save_draft }.to change(Draftsman::Draft.where(id: vanilla.draft_id), :count).by(-1)
+          end
+
+          it 'has a new `updated_at`' do
+            time = vanilla.updated_at
+            vanilla.save_draft
+            vanilla.reload
+            expect(vanilla.updated_at).to be > time
           end
         end
 
@@ -465,6 +535,12 @@ describe Vanilla do
               vanilla.save_draft
               expect(vanilla.draft.create?).to eql true
             end
+
+            it 'has the original `updated_at`' do
+              vanilla.save_draft
+              vanilla.reload
+              expect(vanilla.updated_at).to eq vanilla.created_at
+            end
           end
 
           context 'with no changes' do
@@ -499,6 +575,11 @@ describe Vanilla do
 
             it "doesn't change the number of drafts" do
               expect { vanilla.save_draft }.to_not change(Draftsman::Draft.where(id: vanilla.draft_id), :count)
+            end
+
+            it 'has the original `updated_at`' do
+              vanilla.save_draft
+              expect(vanilla.reload.updated_at).to eq vanilla.created_at
             end
           end
         end
@@ -559,6 +640,13 @@ describe Vanilla do
               vanilla.reload
               expect(vanilla.draft.update?).to eql true
             end
+
+            it 'has a new `updated_at`' do
+              time = vanilla.updated_at
+              vanilla.save_draft
+              vanilla.reload
+              expect(vanilla.updated_at).to be > time
+            end
           end # with changes
 
           context 'with no changes' do
@@ -599,6 +687,13 @@ describe Vanilla do
             it "does not update the draft's `name`" do
               vanilla.save_draft
               expect(vanilla.draft.reify.name).to eql 'Sam'
+            end
+
+            it 'does not update `updated_at`' do
+              time = vanilla.updated_at
+              vanilla.save_draft
+              vanilla.reload
+              expect(vanilla.updated_at).to eq time
             end
           end # with no changes
         end # with existing `update` draft


### PR DESCRIPTION
I use this GEM next to PAPER TRAIL, and found too may versions being stored by PAPER TRAIL with no changes between them. I tracked it down to this gem saving a widget after destroying a draft when the record was changed back to the original values.

To me it makes sense not to save the widget, as no changes are being saved to it.

Makes sense?