### PR TITLE
Update readme to reflect user_for_draftsman in place of user_for_papertrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Draftsman provides a helper extension that acts similarly to the controller
 mixin it provides for Rails applications.
 
 It will set `Draftsman::Draft#whodunnit` to whatever is returned by a method
-named `user_for_paper_trail`, which you can define inside your Sinatra
+named `user_for_draftsman`, which you can define inside your Sinatra
 application. (By default, it attempts to invoke a method named `current_user`.)
 
 If you're using the modular [`Sinatra::Base`][8] style of application, you will


### PR DESCRIPTION
The readme denotes `user_for_papertrail` - in checking the source that isn't currently true (I didn't review when it changed)

Both the Sinatra & Rails frameworks files are using `user_for_draftsman` instead. This is just a small update to fix that outdated reference.